### PR TITLE
Fix exception re-throwing losing callstack of original exception

### DIFF
--- a/STAN.CLIENT/AsyncSubscription.cs
+++ b/STAN.CLIENT/AsyncSubscription.cs
@@ -44,15 +44,12 @@ namespace STAN.Client
         // in STAN, much of this code is in the connection module.
         internal void subscribe(string subRequestSubject, string subject, string qgroup, EventHandler<StanMsgHandlerArgs> handler)
         {
-            Exception exToThrow = null;
-
             rwLock.EnterWriteLock();
-
-            this.handler += handler;
-            this.subject = subject;
-
             try
             {
+                this.handler += handler;
+                this.subject = subject;
+
                 if (sc == null)
                 {
                     throw new StanConnectionClosedException();
@@ -100,19 +97,19 @@ namespace STAN.Client
 
                 ackInbox = r.AckInbox;
             }
-            catch (Exception ex)
+            catch
             {
                 if (inboxSub != null)
                 {
                     inboxSub.Unsubscribe();
                 }
-                exToThrow = ex;
+                
+                throw;
             }
-
-            rwLock.ExitWriteLock();
-
-            if (exToThrow != null)
-                throw exToThrow;
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
         }
 
         public void Unsubscribe()

--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -362,10 +362,10 @@ namespace STAN.Client
             {
                 nc.Publish(subj, localAckSubject, b);
             }
-            catch (Exception e)
+            catch
             {
                 removeAck(guidValue);
-                throw e;
+                throw;
             }
 
             return a;
@@ -403,10 +403,10 @@ namespace STAN.Client
             {
                 sub.subscribe(subRequests, subject, qgroup, handler);
             }
-            catch (Exception ex)
+            catch
             {
                 subMap.Remove(sub.Inbox);
-                throw ex;
+                throw;
             }
 
             return sub;


### PR DESCRIPTION
1. Reworks AsyncSubscription.subscribe to use try..finally to allow clean re-throw of exception and releasing rwLock
2. Cleans up usage of (re)`throw ex` in StanConnection logic