### PR TITLE
Switches argument exceptions to their idiomatic .Net types

### DIFF
--- a/STAN.CLIENT/BlockingChannel.cs
+++ b/STAN.CLIENT/BlockingChannel.cs
@@ -61,7 +61,7 @@ namespace STAN.Client
         internal BlockingDictionary(long maxSize)
         {
             if (maxSize <= 0)
-                throw new ArgumentException("max size must be greater than 0");
+                throw new ArgumentOutOfRangeException("maxSize", maxSize, "maxSize must be greater than 0");
 
             this.maxSize = maxSize;
         }

--- a/STAN.CLIENT/Options.cs
+++ b/STAN.CLIENT/Options.cs
@@ -52,10 +52,7 @@ namespace STAN.Client
             }
             set
             {
-                if (natsURL == null)
-                    natsURL = StanConsts.DefaultNatsURL;
-
-                natsURL = value;
+                natsURL = value != null ? value : StanConsts.DefaultNatsURL;
             }
         }
 
@@ -83,7 +80,7 @@ namespace STAN.Client
             set
             {
                 if (value <= 0)
-                    throw new ArgumentOutOfRangeException("value", "Value must be greater than zero.");
+                    throw new ArgumentOutOfRangeException("value", value, "ConnectTimeout must be greater than zero.");
 
                 connectTimeout = value;
             }
@@ -102,7 +99,7 @@ namespace STAN.Client
             set
             {
                 if (value <= 0)
-                    throw new ArgumentOutOfRangeException("value", "Value must be greater than zero.");
+                    throw new ArgumentOutOfRangeException("value", value, "PubAckWait must be greater than zero.");
 
                 ackTimeout = value;
             }
@@ -121,7 +118,7 @@ namespace STAN.Client
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException("value", "Value cannot be null.");
+                    throw new ArgumentNullException("value", "DiscoverPrefix cannot be null.");
 
                 discoverPrefix = value;
             }
@@ -140,7 +137,7 @@ namespace STAN.Client
             set
             {
                 if (value <= 0)
-                    throw new ArgumentOutOfRangeException("value", "Value must be greater than zero.");
+                    throw new ArgumentOutOfRangeException("value", value, "MaxPubAcksInFlight must be greater than zero.");
 
                 maxPubAcksInflight = value;
             }

--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -85,7 +85,7 @@ namespace STAN.Client
 
         internal void wait()
         {
-            wait(int.MaxValue);
+            wait(Timeout.Infinite);
             if (ex != null)
                 throw ex;
         }
@@ -449,11 +449,11 @@ namespace STAN.Client
         public IStanSubscription Subscribe(string subject, StanSubscriptionOptions options, EventHandler<StanMsgHandlerArgs> handler)
         {
             if (subject == null)
-                throw new ArgumentException("cannot be null", "subject");
+                throw new ArgumentNullException("subject");
             if (options == null)
-                throw new ArgumentException("cannot be null", "options");
+                throw new ArgumentNullException("options");
             if (handler == null)
-                throw new ArgumentException("cannot be null", "handler");
+                throw new ArgumentNullException("handler");
 
             return subscribe(subject, null, handler, options);
         }
@@ -466,13 +466,13 @@ namespace STAN.Client
         public IStanSubscription Subscribe(string subject, string qgroup, StanSubscriptionOptions options, EventHandler<StanMsgHandlerArgs> handler)
         {
             if (subject == null)
-                throw new ArgumentException("cannot be null", "subject");
+                throw new ArgumentNullException("subject");
             if (qgroup == null)
-                throw new ArgumentException("cannot be null", "qgroup");
+                throw new ArgumentNullException("qgroup");
             if (options == null)
-                throw new ArgumentException("cannot be null", "options");
+                throw new ArgumentNullException("options");
             if (handler == null)
-                throw new ArgumentException("cannot be null", "handler");
+                throw new ArgumentNullException("handler");
 
             return subscribe(subject, qgroup, handler, options);
         }

--- a/STAN.CLIENT/SubscriptionOptions.cs
+++ b/STAN.CLIENT/SubscriptionOptions.cs
@@ -30,11 +30,11 @@ namespace STAN.Client
             if (opts == null)
                 return;
 
-            this.ackWait = opts.ackWait;
+            ackWait = opts.ackWait;
 
             if (opts.durableName != null)
             {
-                this.durableName = new String(opts.durableName.ToCharArray());
+                this.durableName = string.Copy(opts.durableName);
             }
 
             manualAcks = opts.manualAcks;
@@ -42,16 +42,8 @@ namespace STAN.Client
             startAt = opts.startAt;
             startSequence = opts.startSequence;
             useStartTimeDelta = opts.useStartTimeDelta;
-
-            if (opts.startTime != null)
-            {
-                startTime = opts.startTime;
-            }
-
-            if (opts.startTimeDelta != null)
-            {
-                startTimeDelta = opts.startTimeDelta;
-            }
+            startTime = opts.startTime;
+            startTimeDelta = opts.startTimeDelta;
         }
 
         /// <summary>
@@ -66,15 +58,14 @@ namespace STAN.Client
         /// <summary>
         /// Controls the number of messages the cluster will have inflight without an ACK.
         /// </summary>
-	    public int MaxInflight
+        public int MaxInflight
         {
             get { return maxInFlight; }
             set
             {
-                if (maxInFlight < 0)
-                {
-                    throw new ArgumentException("value must be > 0");
-                }
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException("value", value, "MaxInflight must be greater than 0");
+
                 maxInFlight = value;
             }
         }
@@ -85,14 +76,14 @@ namespace STAN.Client
         /// <remarks>
         /// The value must be at least one second.
         /// </remarks>
-	    public int AckWait
+        public int AckWait
         {
             get { return ackWait; }
             set
             {
                 if (value < 1000)
-                    throw new ArgumentException("value cannot be less than 1000");
-                        
+                    throw new ArgumentOutOfRangeException("value", value, "AckWait cannot be less than 1000");
+ 
                 ackWait = value;
             }
         }
@@ -100,7 +91,7 @@ namespace STAN.Client
         /// <summary>
         /// Controls the time the cluster will wait for an ACK for a given message.
         /// </summary>
-	    public bool ManualAcks
+        public bool ManualAcks
         {
             get { return manualAcks; }
             set { manualAcks = value; }
@@ -110,7 +101,7 @@ namespace STAN.Client
         /// Optional start sequence number.
         /// </summary>
         /// <param name="sequence"></param>
-	    public void StartAt(ulong sequence)
+        public void StartAt(ulong sequence)
         {
             startAt = StartPosition.SequenceStart;
             startSequence = sequence;    
@@ -120,7 +111,7 @@ namespace STAN.Client
         /// Optional start time.
         /// </summary>
         /// <param name="time"></param>
-	    public void StartAt(DateTime time)
+        public void StartAt(DateTime time)
         {
             useStartTimeDelta = false;
             startTime = time;
@@ -143,7 +134,7 @@ namespace STAN.Client
         /// </summary>
         public void StartWithLastReceived()
         {
-		    startAt = StartPosition.LastReceived;
+            startAt = StartPosition.LastReceived;
         }
 
         /// <summary>

--- a/STAN.Client.UnitTests/UnitTestBasic.cs
+++ b/STAN.Client.UnitTests/UnitTestBasic.cs
@@ -860,7 +860,7 @@ namespace STAN.Client.UnitTests
 
                     var sOpts = StanSubscriptionOptions.GetDefaultOptions();
                     // make sure we get an error from an invalid Ack wait
-                    Assert.Throws<ArgumentException>(() => { sOpts.AckWait = 500; });
+                    Assert.Throws<ArgumentOutOfRangeException>(() => { sOpts.AckWait = 500; });
 
                     int ackRedeliverTime = 1000;
 
@@ -910,7 +910,7 @@ namespace STAN.Client.UnitTests
 
                     var sOpts = StanSubscriptionOptions.GetDefaultOptions();
                     // make sure we get an error from an invalid Ack wait
-                    Assert.Throws<ArgumentException>(() => { sOpts.AckWait = 500; });
+                    Assert.Throws<ArgumentOutOfRangeException>(() => { sOpts.AckWait = 500; });
 
                     int ackRedeliverTime = 1000;
 


### PR DESCRIPTION
1. Switches usage of basic `ArgumentException` to the more idiomatic exception type, if one exists.
2. Corrects assignment logic in StanOptions.NatsURL's setter
3. Switches `int.MaxValue` to `Timeout.Infinite` in `PublishAck.wait()`, as `Monitor.Wait(object, int)` expects `-1` rather than `int.MaxValue` to mean "block forever".
4. Removes struct comparisons to `null` in StanSubscriptionOptions
5. Corrects argument range check logic in StanSubscriptionOptions.MaxInflight