### PR TITLE
Allow UTC or local time for StanSubscriptionOptions.StartAt(DateTime)

### DIFF
--- a/STAN.CLIENT/AsyncSubscription.cs
+++ b/STAN.CLIENT/AsyncSubscription.cs
@@ -74,7 +74,7 @@ namespace STAN.Client
                         sr.StartTimeDelta = convertTimeSpan(
                             options.useStartTimeDelta ? 
                                 options.startTimeDelta : 
-                                (DateTime.Now - options.startTime));
+                                (DateTime.UtcNow - options.startTime));
                         break;
                     case StartPosition.SequenceStart:
                         sr.StartSequence = options.startSequence;

--- a/STAN.CLIENT/SubscriptionOptions.cs
+++ b/STAN.CLIENT/SubscriptionOptions.cs
@@ -108,13 +108,15 @@ namespace STAN.Client
         }
 
         /// <summary>
-        /// Optional start time.
+        /// Optional start time.  UTC is recommended although a local time will be converted to UTC.
         /// </summary>
         /// <param name="time"></param>
         public void StartAt(DateTime time)
         {
             useStartTimeDelta = false;
-            startTime = time;
+            startTime = (time.Kind == DateTimeKind.Utc) ? time :
+                time.ToUniversalTime();
+
             startAt = StartPosition.TimeDeltaStart;
         }
 


### PR DESCRIPTION
Allow UTC or local time to be used in the StanSubscriptionOptions.StartAt(DateTime) method.  UTC is recommended, but the time passed is is local an attempt will be made to convert it.

Resolves https://github.com/nats-io/csharp-nats-streaming/issues/22