### PR TITLE
Move to .NET v4.5

### DIFF
--- a/net45/STAN.Client.UnitTests/STAN.Client.UnitTests.csproj
+++ b/net45/STAN.Client.UnitTests/STAN.Client.UnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>STAN.Client.UnitTests</RootNamespace>
     <AssemblyName>STAN.Client.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/net45/STAN.Client.UnitTests/app.config
+++ b/net45/STAN.Client.UnitTests/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
 </configuration>

--- a/net45/STAN.Client/STAN.Client.csproj
+++ b/net45/STAN.Client/STAN.Client.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>STAN.Client</RootNamespace>
     <AssemblyName>STAN.CLIENT</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/net45/examples/stan-pub/App.config
+++ b/net45/examples/stan-pub/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
 </configuration>

--- a/net45/examples/stan-pub/stan-pub.csproj
+++ b/net45/examples/stan-pub/stan-pub.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>STAN.Examples</RootNamespace>
     <AssemblyName>stan-pub</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/net45/examples/stan-sub/App.config
+++ b/net45/examples/stan-sub/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
 </configuration>

--- a/net45/examples/stan-sub/stan-sub.csproj
+++ b/net45/examples/stan-sub/stan-sub.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>STAN.Examples</RootNamespace>
     <AssemblyName>stan-sub</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
Previous builds were v4.5.2.  Since there is code compatibility, support users on older versions of the framework.

Resolves #32 