### PR TITLE
Protect condition vars against spurious wakeups

### DIFF
--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -75,7 +75,7 @@ namespace STAN.Client
         {
             lock (cond)
             {
-                if (!isComplete)
+                while (!isComplete)
                 {
                     Monitor.Wait(cond, timeout);
                 }
@@ -340,7 +340,7 @@ namespace STAN.Client
                 if (nc == null)
                     throw new StanConnectionClosedException();
 
-                if (pubAckMap.isAtCapacity())
+                while (!pubAckMap.TryAdd(guidValue, a))
                 {
                     var bd = pubAckMap;
 
@@ -356,7 +356,6 @@ namespace STAN.Client
                     }
                 }
 
-                pubAckMap.Add(guidValue, a);
                 localAckSubject = ackSubject;
                 localAckTimeout = opts.ackTimeout;
             }
@@ -408,7 +407,11 @@ namespace STAN.Client
             }
             catch
             {
-                subMap.Remove(sub.Inbox);
+                lock (mu)
+                {
+                    subMap.Remove(sub.Inbox);
+                }
+
                 throw;
             }
 


### PR DESCRIPTION
BlockingDictionary utilized two conditions (empty and gull) without rechecking the condition
after waking up. There exists the possibility that either condition may not still be valid after the waiting
thread wakes up. This patch adds loops on the condition variables used internally to guard against
spurious wakeups. Additionally, the calling code in StanConnection was structured such that even
without spurious wakeups, a window of opportunity existed in between the isAtCapacity check then
wait and the actual Add call. In brute force testing of BlockingDictionary, external to the library, the
`d.Count < maxSize` invariant for Add could be violated with that race condition. The code is restructured to utilize the TryAdd pattern instead. The Remove path also corrects a logical bug where duplicate TryGetValue calls were
made.

PublishAck utilized one condition variable (isComplete) without rechecking the condition after waking up.
A loop was added in PublishAck.wait(int timeout) to ensure the condition is still met after the thread
wakes up. Admittedly I was unable to exploit the possibility in brute force testing.

A minor patch is included to protect subMap.Remove with a lock on mu in the exception case during
subscription.