### PR TITLE
Ensure server start/stop behavior in unit tests

### DIFF
--- a/STAN.Client.UnitTests/UnitTestUtilities.cs
+++ b/STAN.Client.UnitTests/UnitTestUtilities.cs
@@ -41,11 +41,16 @@ namespace STAN.Client.UnitTests
             debug = shouldDebug;
             ProcessStartInfo psInfo = createProcessStartInfo();
             p = Process.Start(psInfo);
-            for (int i = 0; i < 20; i++)
+            for (int i = 1; i <= 20; i++)
             {
-                Thread.Sleep(500);
+                Thread.Sleep(100*i);
                 if (isNatsServerRunning())
                     break;
+            }
+
+            if (p.HasExited)
+            {
+                Console.WriteLine("Server failure with exit code: " + p.ExitCode);
             }
             // Allow the Nats streaming server to setup.
             Thread.Sleep(250);

--- a/STAN.Client.UnitTests/UnitTestUtilities.cs
+++ b/STAN.Client.UnitTests/UnitTestUtilities.cs
@@ -128,6 +128,7 @@ namespace STAN.Client.UnitTests
             try
             {
                 p.Kill();
+                p.WaitForExit(60000);
             }
             catch (Exception) { }
 

--- a/STAN.Client.UnitTests/UnitTestUtilities.cs
+++ b/STAN.Client.UnitTests/UnitTestUtilities.cs
@@ -50,10 +50,10 @@ namespace STAN.Client.UnitTests
 
             if (p.HasExited)
             {
-                Console.WriteLine("Server failure with exit code: " + p.ExitCode);
+                throw new Exception("Server failure with exit code: " + p.ExitCode);
             }
             // Allow the Nats streaming server to setup.
-            Thread.Sleep(250);
+            Thread.Sleep(1000);
         }
 
         public NatsStreamingServer()


### PR DESCRIPTION
When CI runs slowly, the server needs extra time to start in unit tests, and may linger after being killed.  Create a backoff timer to check for server start, and print the server exit code if the streaming server does not start.  This slows tests down, but helps eliminate flappers when AppVeyor is very slow.