### PR TITLE
Remove unnecessary allocation

### DIFF
--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -311,8 +311,6 @@ namespace STAN.Client
             if (isClosed || sub == null)
                 return;
 
-            StanMsg msg = new StanMsg(mp, sub);
-
             sub.processMsg(mp);
         }
 


### PR DESCRIPTION
Remove a unnecessary allocation of a message before processing.

Signed-off-by: Colin Sullivan <colin@synadia.com>