### PR TITLE
Example on stan-sub's "-server" option is incorrect #81

### DIFF
--- a/examples/stan-pub/stan-pub.cs
+++ b/examples/stan-pub/stan-pub.cs
@@ -11,7 +11,7 @@ namespace STAN.Example.Publish
     {
         static readonly string usageText =
 @"Usage: stan-pub
-	-server <url> NATS Streaming server URL(s)
+	-url <url> NATS Streaming server URL(s)
 	-cluster <cluster name> NATS Streaming cluster name
 	-clientid <client ID> NATS Streaming client ID
     -subject <subject> subject to publish on, defaults to foo.

--- a/examples/stan-sub/stan-sub.cs
+++ b/examples/stan-sub/stan-sub.cs
@@ -24,7 +24,7 @@ namespace STAN.Example.Subscribe
 @"
 Usage: stan-sub [options] <subject>
 Options:
-    -server < url >           NATS Streaming server URL(s)
+    -url < url >           NATS Streaming server URL(s)
     -cluster < cluster name > NATS Streaming cluster name
     -clientid < client ID >   NATS Streaming client ID
     -verbose                  Verbose mode (affects performance).


### PR DESCRIPTION
I presume the code is correct (-url) and the usage text (-server) is what is out of date.