### PR TITLE
Add detail and documentation for the StanConnectRequestTimeoutException

### DIFF
--- a/STAN.CLIENT/STANExceptions.cs
+++ b/STAN.CLIENT/STANExceptions.cs
@@ -84,11 +84,19 @@ namespace STAN.Client
     }
 
     /// <summary>
-    /// An exception representing the case when a connection attempt times out.
+    /// An exception representing the case when a streaming connection attempt
+    /// fails due to a mismatched cluster id or connectivity with a streaming
+    /// server.
     /// </summary>
+    /// <remarks>
+    /// This is exception is thrown due to a mismatch between the cluster ID
+    /// of the client and the streaming server or when there is connectivity
+    /// with a core NATS server but not a streaming server.
+    /// </remarks>
     public class StanConnectRequestTimeoutException : StanTimeoutException
     {
         internal StanConnectRequestTimeoutException() : base("Connection Request Timed out.") { }
+        internal StanConnectRequestTimeoutException(string msg) : base(msg) { }
     }
 
     /// <summary>

--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -245,7 +245,8 @@ namespace STAN.Client
             catch (NATSTimeoutException)
             {
                 protoUnsubscribe();
-                throw new StanConnectRequestTimeoutException();
+                throw new StanConnectRequestTimeoutException(
+                    string.Format("No response from a streaming server with a cluster ID of '{0}'", stanClusterID));
             }
 
             ConnectResponse response = new ConnectResponse();

--- a/STAN.CLIENT/StanConnectionFactory.cs
+++ b/STAN.CLIENT/StanConnectionFactory.cs
@@ -21,10 +21,12 @@ namespace STAN.Client
         /// <summary>
         /// Creates a connection to the server.
         /// </summary>
-        /// <param name="clusterID"></param>
-        /// <param name="clientID"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
+        /// <param name="clusterID">The cluster ID of streaming server.</param>
+        /// <param name="clientID">A unique ID for this connection.</param>
+        /// <param name="options">Connection options.</param>
+        /// <exception cref="StanConnectionException">Thrown when core NATS is unable to connect to a server.</exception>
+        /// <exception cref="StanConnectRequestTimeoutException">Thrown when there is an invalid cluster id or other connectivity issues.</exception>
+        /// <returns>A connection to a streaming server.</returns>
         public IStanConnection CreateConnection(string clusterID, string clientID, StanOptions options)
         {
             return new Connection(clusterID, clientID, options);
@@ -33,9 +35,11 @@ namespace STAN.Client
         /// <summary>
         /// Creates a connection to the server.
         /// </summary>
-        /// <param name="clusterID"></param>
-        /// <param name="clientID"></param>
-        /// <returns></returns>
+        /// <param name="clusterID">The cluster ID of streaming server.</param>
+        /// <param name="clientID">A unique ID for this connection.</param>
+        /// <exception cref="StanConnectionException">Thrown when core NATS is unable to connect to a server.</exception>
+        /// <exception cref="StanConnectRequestTimeoutException">Thrown when there is an invalid cluster id or other connectivity issues.</exception>
+        /// <returns>A connection to a streaming server.</returns>
         public IStanConnection CreateConnection(string clusterID, string clientID)
         {
             return new Connection(clusterID, clientID, null);

--- a/STAN.Client.UnitTests/UnitTestBasic.cs
+++ b/STAN.Client.UnitTests/UnitTestBasic.cs
@@ -58,10 +58,19 @@ namespace STAN.Client.UnitTests
         [Fact]
         public void TestUnreachable()
         {
+            bool thrown = false;
             using (new NatsStreamingServer())
             {
-                Assert.Throws<StanConnectRequestTimeoutException>(
-                    () => new StanConnectionFactory().CreateConnection("invalid", CLIENT_ID));
+                try
+                {
+                    new StanConnectionFactory().CreateConnection("invalid-cluster", CLIENT_ID);
+                }
+                catch (StanConnectRequestTimeoutException se)
+                {
+                    thrown = true;
+                    Assert.Contains("invalid-cluster", se.Message);
+                }
+                Assert.True(thrown);
             }
         }
 


### PR DESCRIPTION
While the `StanConnectRequestTimeoutException` is accurate, it can be misleading when there is a configuration mismatch between the client cluster ID and the server's configured cluster ID.  Ideally, a different exception should be thrown, but we want to maintain backward compatibility.  To make behavior clearer:

* Add documentation to describe this scenario.
* Add the cluster ID in the exception message for the user to check.
 
Resolves #93 

Signed-off-by: Colin Sullivan <colin@synadia.com>