### PR TITLE
Fix the default acknowledgment wait timeout 

### DIFF
--- a/STAN.CLIENT/Options.cs
+++ b/STAN.CLIENT/Options.cs
@@ -23,7 +23,7 @@ namespace STAN.Client
         internal string natsURL = StanConsts.DefaultNatsURL;
         internal IConnection natsConn = null;
         internal int connectTimeout = StanConsts.DefaultConnectWait;
-        internal long ackTimeout = StanConsts.DefaultConnectWait;
+        internal long ackTimeout = StanConsts.DefaultAckWait;
         internal string discoverPrefix = StanConsts.DefaultDiscoverPrefix;
         internal long maxPubAcksInflight = StanConsts.DefaultMaxPubAcksInflight;
         internal int pingMaxOut = StanConsts.DefaultPingMaxOut;


### PR DESCRIPTION
The default acknowledgment wait timeout was erroneously set to the default connection timeout; set it to the proper value.

Signed-off-by: Colin Sullivan <colin@synadia.com>