### PR TITLE
Bump master version to 0.1.7

### DIFF
--- a/STAN.CLIENT/Properties/AssemblyInfo.cs
+++ b/STAN.CLIENT/Properties/AssemblyInfo.cs
@@ -44,5 +44,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.6.0")]
-[assembly: AssemblyFileVersion("0.1.6.0")]
+[assembly: AssemblyVersion("0.1.7.0")]
+[assembly: AssemblyFileVersion("0.1.7.0")]

--- a/STAN.CLIENT/STAN.CLIENT.csproj
+++ b/STAN.CLIENT/STAN.CLIENT.csproj
@@ -4,7 +4,7 @@
     <Description>STAN Client API</Description>
     <Copyright>Copyright © The NATS Authors 2017-2019</Copyright>
     <AssemblyTitle>STAN Client</AssemblyTitle>
-    <VersionPrefix>0.1.6</VersionPrefix>
+    <VersionPrefix>0.1.7</VersionPrefix>
     <TargetFramework>netstandard1.6</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>STAN.CLIENT</AssemblyName>
@@ -18,7 +18,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>0.1.6</Version>
+    <Version>0.1.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/STAN.Client.nuspec
+++ b/nuget/STAN.Client.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>STAN.Client</id>
-        <version>0.1.6.0</version>
+        <version>0.1.7.0</version>
         <title>NATS Streaming .NET Client</title>
         <authors>The NATS Authors</authors>
         <owners>CNCF</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>NATS acts as a central nervous system for distributed systems at scale, such as mobile devices, IoT networks, and cloud native infrastructure.  This is the .NET Streaming client API.</description>
         <summary>NATS Streaming .NET Client</summary>
-        <releaseNotes>See https://github.com/nats-io/csharp-nats-streaming/releases/v0.1.6</releaseNotes>
+        <releaseNotes>See https://github.com/nats-io/csharp-nats-streaming/releases/v0.1.7</releaseNotes>
         <copyright>Copyright 2017-2019 The NATS Authors</copyright>
         <language />
         <repository type="git" url="https://github.com/nats-io/csharp-nats-streaming" />


### PR DESCRIPTION
A small version bump just to distinguish repo master branch builds from what is on Nuget.  I think the next released version should jump to 0.2.0.

Signed-off-by: Colin Sullivan <colin@synadia.com>