### PR TITLE
Fix a NullReferenceException thrown in the Close API

### DIFF
--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -450,7 +450,7 @@ namespace STAN.Client
             {
                 if (pubAckMap.Remove(guid, out pa, 0))
                 {
-                    pa.InvokeHandler(guid, ex.Message == null ? "Connection Closed." : ex.Message);
+                    pa.InvokeHandler(guid, ex == null ? "Connection Closed." : ex.Message);
                 }
             }
         }

--- a/STAN.Client.UnitTests/UnitTestBasic.cs
+++ b/STAN.Client.UnitTests/UnitTestBasic.cs
@@ -762,6 +762,38 @@ namespace STAN.Client.UnitTests
         }
 
         [Fact]
+        public void TestCloseWithAcksInFlight()
+        {
+            using (new NatsStreamingServer())
+            {
+                var c = DefaultConnection;
+                bool okMessage = false;
+
+                EventHandler<StanAckHandlerArgs> ah = (o, a) =>
+                {
+                    if (a.Error != null)
+                    {
+                        okMessage = a.Error.Contains("Closed");
+                    }
+                    else
+                    {
+                        // Stack up the event handlers
+                        Thread.Sleep(1000);
+                    }
+                };
+
+                for (int i = 0; i < 25; i++)
+                {
+                    c.Publish("foo", null, ah);
+                }
+
+                c.Close();
+
+                Assert.True(okMessage);
+            }
+        }
+
+        [Fact]
         public void TestDoubleClose()
         {
             using (new NatsStreamingServer())


### PR DESCRIPTION
[FIXED] The exception Message was being checked for null rather than the exception itself.

Resolves #122 

Signed-off-by: Colin Sullivan <colin@synadia.com>